### PR TITLE
extract floating point numbers

### DIFF
--- a/sems_portal_api/sems_home_wrapper.py
+++ b/sems_portal_api/sems_home_wrapper.py
@@ -14,9 +14,9 @@ def extract_number(s):
     """Remove units from string and turn to number."""
 
     # Match one or more digits at the beginning of the string
-    match = re.match(r"(\d+)", s)
+    match = re.match(r"(\d+(\.\d+))", s)
     if match:
-        return int(match.group(1))
+        return float(match.group(1))
 
     return None
 


### PR DESCRIPTION
Before only the integer part of the number was extracted, with this little change the fractional part is also extracted.
So strings like
```
"0W"
"1.2kW"
"1.2"
"1"
```
can now be parsed by this function, giving the user more exact results.