### PR TITLE
add support for region

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ To use SEMS Portal, you need to have Python and `aiohttp` installed. Here’s a 
 ```python
 import aiohttp
 import asyncio
-from sems_portal_api import login_to_sems
+from sems_portal_api import login_to_sems, set_region
 
 async def main():
+    set_region('eu')
     async with aiohttp.ClientSession() as session:
         account = "your_account"
         password = "your_password"
@@ -46,6 +47,12 @@ In this example, we import the required modules and define an `async` main funct
 
 The `login_to_sems` function takes three parameters: the session, account, and password, and it returns the data received from the SEMS portal. The returned data is then printed to the console.
 
+
+For testing the demo account credentials may be used:
+```python
+account = "demo@goodwe.com"
+password = "GoodweSems123!@#"
+```
 
 ## Contributing
 Contributions to SEMS Portal are welcome and appreciated. If you have any suggestions or bug reports, please open an issue in the repository.

--- a/sems_portal_api/__init__.py
+++ b/sems_portal_api/__init__.py
@@ -1,3 +1,4 @@
 from .sems_auth import login_to_sems
 from .sems_charts import get_plant_power_chart
 from .sems_home_wrapper import get_collated_plant_details
+from .sems_region import set_region

--- a/sems_portal_api/sems_auth.py
+++ b/sems_portal_api/sems_auth.py
@@ -4,6 +4,9 @@ from typing import Any
 
 from aiohttp import ClientSession
 
+import base64
+
+from sems_portal_api.sems_region import get_region
 
 async def login_to_sems(session: ClientSession, account: str, pwd: str) -> Any:
     """Login to the SEMS portal."""
@@ -15,6 +18,22 @@ async def login_to_sems(session: ClientSession, account: str, pwd: str) -> Any:
     body = {"account": account, "pwd": pwd}
 
     response = await session.post(url, headers=headers, json=body, timeout=5)
+    response_data = await response.json()
+
+    return response_data["data"]
+
+def login_response_to_token(login_data: Any) -> str:
+    return base64.b64encode(bytes(str(login_data), 'utf-8')).decode('utf-8')
+
+async def get_station_ids(session: ClientSession, token: str) -> Any:
+    """Get the station id of an account"""
+    url = f"https://{get_region()}.semsportal.com/api/PowerStation/GetPowerStationIdByOwner"
+    headers = {
+        "Content-Type": "application/json",
+        "Token": token,
+    }
+
+    response = await session.post(url, headers=headers, timeout=5)
     response_data = await response.json()
 
     return response_data["data"]

--- a/sems_portal_api/sems_charts.py
+++ b/sems_portal_api/sems_charts.py
@@ -5,13 +5,15 @@ from typing import Any
 
 from aiohttp import ClientSession
 
+from sems_portal_api.sems_region import get_region
+
 
 async def get_plant_power_chart(
     session: ClientSession, plant_id: str, token: str, targetDate: datetime = datetime.now()
 ) -> Any:
     """Retrieve powerplant chart data."""
     formatted_date = targetDate.strftime("%Y-%m-%d")
-    url = "https://au.semsportal.com/api/v2/Charts/GetPlantPowerChart"
+    url = f"https://{get_region()}.semsportal.com/api/v2/Charts/GetPlantPowerChart"
     headers = {"Content-Type": "application/json", "Token": token}
     body = {"id": plant_id, "date": formatted_date, "full_script": False}
 

--- a/sems_portal_api/sems_home_wrapper.py
+++ b/sems_portal_api/sems_home_wrapper.py
@@ -30,6 +30,7 @@ async def get_collated_plant_details(
         power_station_id=power_station_id,
         token=token,
     )
+    powerflow_information = plant_information["powerflow"]
 
     plantDetails = await get_plant_details(
         session=session,
@@ -59,25 +60,6 @@ async def get_collated_plant_details(
                 "allTimeGeneration": plantDetails["kpi"]["total_power"],
                 "todayIncome": plantDetails["kpi"]["day_income"],
                 "totalIncome": plantDetails["kpi"]["total_income"],
-                "generationLive": extract_number(
-                    plant_information["powerflow"]["pv"]
-                ),
-                "pvStatus": plant_information["powerflow"]["pvStatus"],
-                "battery": extract_number(
-                    plant_information["powerflow"]["bettery"]
-                ),
-                "batteryStatus": plant_information["powerflow"]["betteryStatus"],
-                "batteryStatusStr": plant_information["powerflow"][
-                    "betteryStatusStr"
-                ],
-                "houseLoad": extract_number(plant_information["powerflow"]["load"]),
-                "houseLoadStatus": plant_information["powerflow"]["loadStatus"],
-                "gridLoad": extract_number(plant_information["powerflow"]["grid"]),
-                "gridLoadStatus": plant_information["powerflow"]["gridStatus"],
-                "soc": plant_information["powerflow"]["soc"],
-                "socText": extract_number(
-                    plant_information["powerflow"]["socText"]
-                ),
             },
             "inverters": [{
                 "name": inverter["sn"],
@@ -86,5 +68,28 @@ async def get_collated_plant_details(
             } for inverter in inverterDetails],
         }
     }
+
+    if powerflow_information is not None:
+        data["powerPlant"]["info"].update({
+            "generationLive": extract_number(
+                powerflow_information["pv"]
+            ),
+            "pvStatus": powerflow_information["pvStatus"],
+            "battery": extract_number(
+                powerflow_information["bettery"]
+            ),
+            "batteryStatus": powerflow_information["betteryStatus"],
+            "batteryStatusStr": powerflow_information[
+                "betteryStatusStr"
+            ],
+            "houseLoad": extract_number(powerflow_information["load"]),
+            "houseLoadStatus": powerflow_information["loadStatus"],
+            "gridLoad": extract_number(powerflow_information["grid"]),
+            "gridLoadStatus": powerflow_information["gridStatus"],
+            "soc": powerflow_information["soc"],
+            "socText": extract_number(
+                powerflow_information["socText"]
+            ),
+        })
 
     return data

--- a/sems_portal_api/sems_plant_details.py
+++ b/sems_portal_api/sems_plant_details.py
@@ -4,12 +4,14 @@ from typing import Any
 
 from aiohttp import ClientSession
 
+from sems_portal_api.sems_region import get_region
+
 
 async def get_plant_details(
     session: ClientSession, power_station_id: str, token: str
 ) -> Any:
     """Get powerplant details."""
-    url = "https://au.semsportal.com/api/v3/PowerStation/GetPlantDetailByPowerstationId"
+    url = f"https://{get_region()}.semsportal.com/api/v3/PowerStation/GetPlantDetailByPowerstationId"
     headers = {"Content-Type": "application/json", "Token": token}
     body = {"PowerStationId": power_station_id}
 
@@ -24,9 +26,10 @@ async def get_powerflow(
 ) -> Any:
     """Get the powerflow data."""
 
-    url = "https://au.semsportal.com/api/v2/PowerStation/GetPowerflow"
+    url = f"https://{get_region()}.semsportal.com/api/v2/PowerStation/GetPowerflow"
     headers = {"Content-Type": "application/json", "Token": token}
     body = {"PowerStationId": power_station_id}
+
 
     response = await session.post(url, headers=headers, json=body, timeout=5)
     response_data = await response.json()
@@ -39,7 +42,7 @@ async def get_inverter_details(
 ) -> Any:
     """Get the inverter data."""
 
-    url = "https://au.semsportal.com/api/v3/PowerStation/GetInverterAllPoint"
+    url = f"https://{get_region()}.semsportal.com/api/v3/PowerStation/GetInverterAllPoint"
     headers = {"Content-Type": "application/json", "Token": token}
     body = {"PowerStationId": power_station_id}
 

--- a/sems_portal_api/sems_region.py
+++ b/sems_portal_api/sems_region.py
@@ -1,0 +1,11 @@
+
+region = "au"
+
+def set_region(new_region: str):
+	global region
+	region = new_region
+
+def get_region() -> str:
+	global region
+	return region
+


### PR DESCRIPTION
The api requires you to select the correct region.

Currently i have just added a function to define the region to use. But  it would be possible to find the region automaticly by parsing the response html of `https://semsportal.com/home/login` as it contains js where we could extract the region from:
```javascript
var gops_api_domain = "https://eu.semsportal.com/api/";
```

I also found out about an example account. As far as i know that account does only work in the eu region, but maybe similar accounts exists in other regions.

The example account has no powerflow available. To stop the api from crashing in such case, i added an if to check for availablity of that field.