### PR TITLE
Fix two problems

### DIFF
--- a/sems_portal_api/__init__.py
+++ b/sems_portal_api/__init__.py
@@ -1,4 +1,4 @@
-from .sems_auth import login_to_sems
+from .sems_auth import login_to_sems, get_station_ids, login_response_to_token
 from .sems_charts import get_plant_power_chart
 from .sems_home_wrapper import get_collated_plant_details
 from .sems_region import set_region

--- a/sems_portal_api/sems_home_wrapper.py
+++ b/sems_portal_api/sems_home_wrapper.py
@@ -14,7 +14,7 @@ def extract_number(s):
     """Remove units from string and turn to number."""
 
     # Match one or more digits at the beginning of the string
-    match = re.match(r"(\d+(\.\d+))", s)
+    match = re.match(r"(\d+(\.\d+)?)", s)
     if match:
         return float(match.group(1))
 
@@ -64,7 +64,7 @@ async def get_collated_plant_details(
             "inverters": [{
                 "name": inverter["sn"],
                 "model": get_value_by_key(inverter["dict"]["left"], "dmDeviceType"),
-                "innerTemp": get_value_by_key(inverter["dict"]["right"], "innerTemp"),
+                "innerTemp": extract_number(get_value_by_key(inverter["dict"]["left"], "innerTemp")),
             } for inverter in inverterDetails],
         }
     }


### PR DESCRIPTION
In the last two pull requests i made two little oupsies.

I somehow managed to get the number parsing function slightly wrong (strings like '0W' did not work anymore)
I don't know how that case managed to sneak through my testing (i was sure i tested it).

I also added two of the helper functions to the export in `__init__.py`.

the `innerTemp` was inside the "left" part of the dict. I dont know if that is always the case, or if that is somewhat random. maybe there needs to be a slightly more advanced function to parse that.